### PR TITLE
[Bug] Adding missing action to the policy permission for GCLambdaExecutionRole

### DIFF
--- a/arch/lza_extensions/customizations/GCGuardrailsRoles.yaml
+++ b/arch/lza_extensions/customizations/GCGuardrailsRoles.yaml
@@ -135,6 +135,7 @@ Resources:
           - Sid: AllowES
             Action:
               - "es:ListDomainNames"
+              - "es:DescribeDomains"
               - "es:DescribeElasticsearchDomains"
             Resource: "*"
             Effect: Allow

--- a/arch/templates/AllAccountPreRequisites.yaml
+++ b/arch/templates/AllAccountPreRequisites.yaml
@@ -295,6 +295,7 @@ Resources:
           - Sid: AllowES
             Action:
               - "es:ListDomainNames"
+              - "es:DescribeDomains"
               - "es:DescribeElasticsearchDomains"
             Resource: "*"
             Effect: Allow

--- a/arch/templates/AuditAccountPreRequisitesPart1.yaml
+++ b/arch/templates/AuditAccountPreRequisitesPart1.yaml
@@ -306,6 +306,8 @@ Resources:
             Action:
               - "es:ListDomainNames"
               - "es:DescribeDomain"
+              - "es:DescribeDomains"
+              - "es:DescribeElasticsearchDomain"
               - "es:DescribeElasticsearchDomains"
             Resource: "*"
             Effect: Allow

--- a/arch/templates/main.yaml
+++ b/arch/templates/main.yaml
@@ -370,7 +370,10 @@ Resources:
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "es:ListDomainNames",
+                "es:DescribeElasticsearchDomain",
                 "es:DescribeElasticsearchDomains",
+                "es:DescribeDomain",
+                "es:DescribeDomains",
                 "tag:GetResources"
               ],
               "Resource": [


### PR DESCRIPTION
# AWS CAC Solution PR Template

## Pull Request Type
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation Update
- [ ] Other (Please specify)

## Description
Adding missing action to the policy permission for GCLambdaExecutionRole
Following two are needed for GR06_part2
- "es:DescribeElasticsearchDomain"
- "es:DescribeDomain"

and the following two are needed for GR07
- "es:DescribeElasticsearchDomains"
- "es:DescribeDomains"

## Related Issue(s)
Will be closing this [issue](https://github.com/orgs/ssc-spc-ccoe-cei/projects/12?pane=issue&itemId=56031925)

## How Has This Been Tested?
Ran client side testing

### CloudFormation Linter Results
N/A

### Deployment Test Results
Success

## Screenshots (if appropriate)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated any related documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [ ] I have added comments to my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes require a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the final deliverable aligns with the CloudFormation best practices.

## Additional Notes
Include any additional information that you think is important for reviewers.
