### PR TITLE
[Bug fix] Update lambda permission

### DIFF
--- a/arch/templates/AuditAccountPreRequisitesPartN.yaml
+++ b/arch/templates/AuditAccountPreRequisitesPartN.yaml
@@ -106,3 +106,31 @@ Resources:
         Variables:
           OrganizationName:
             Ref: OrganizationName
+  
+  CronTriggerLambdaPermissions:
+    Condition: IsAuditAccount
+    Type: AWS::Events::Rule
+    Properties:
+      EventBusName: default
+      Name: update-lambda-permissions-every-6-hours
+      ScheduleExpression: cron(0 */6 * * ? *)
+      State: ENABLED
+      Targets:
+        - Id: !Sub ${OrganizationName}update-lambda-permissions
+          Arn: !GetAtt LambdaPermissionsLambda.Arn
+          Input: |-
+            {
+                "RequestType": "Cron"
+            }
+
+  PermissionForEvent0ToInvokeLambda:
+    Condition: IsAuditAccount
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: LambdaPermissionsLambda
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn:
+        Fn::GetAtt:
+          - "CronTriggerLambdaPermissions"
+          - "Arn"

--- a/src/lambda/aws_lambda_permissions_setup/app.py
+++ b/src/lambda/aws_lambda_permissions_setup/app.py
@@ -1,4 +1,7 @@
 """ Setup Lambda Permissions """
+# This needs to be updated to run on a cronjob as well as modified to be used outside of a custom resource, otherwise new account will not
+# be able to access the config rules
+# Eventbridge rule run every 6 hours
 import os
 import json
 import logging
@@ -256,6 +259,15 @@ def lambda_handler(event, context):
         res = event["PhysicalResourceId"]
         response_data["lower"] = res.lower()
         send(event, context, SUCCESS, response_data)
+    elif event["RequestType"] == "Cron":
+        # try to validate the lambda permissions
+        result = apply_lambda_permissions()
+        if result != 1:
+            # we failed
+            response_data["Reason"] = "Failed to update the Lambda Permissions. Check CloudWatch Logs."
+        else:
+            # success
+            response_data["Reason"] = "Successfully validated the Lambda Permissions. Check CloudWatch Logs."
     else:  # delete / update
         # something else, need to raise error
         send(event, context, FAILED, response_data, response_data["lower"])


### PR DESCRIPTION
# AWS CAC Solution PR Template

## Pull Request Type
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation Update
- [ ] Other (Please specify)

## Description
Updating lambda permission function and the deployment so that new accounts are able to access the config rules.
Eventbridge rule runs every 6 hours and updates the custom check lambda resource policy.

## Related Issue(s)
Related to #26 on new accounts

## How Has This Been Tested?
Will be tested in test tenant on new accounts

### CloudFormation Linter Results
N/A

### Deployment Test Results
Provide details of any deployment tests you have conducted.

## Screenshots (if appropriate)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated any related documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have added comments to my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes require a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the final deliverable aligns with the CloudFormation best practices.

## Additional Notes
N/A
