### PR TITLE
[BugFix] - fix release pipeline to trigger on numeric version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: AWS CAC Release
 on:
   push:
     tags:
-      - 'v*'
-
+      - '[0-9]*.*'
+      
 env:
     REGION: ca-central-1
 


### PR DESCRIPTION
# AWS CAC Solution PR Template

## Pull Request Type
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation Update
- [ ] Other (Please specify)

## Description
Removed the requirement to have v Infront of version to make it consistent with version specified in CloudFormation template. 

## Related Issue(s)
#15 
## How Has This Been Tested?
N/A

### CloudFormation Linter Results
Include the output of the CloudFormation linter (if used).

### Deployment Test Results
N/A

## Screenshots (if appropriate)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated any related documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes generate no new warnings.
- [ ] I have added comments to my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes require a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the final deliverable aligns with the CloudFormation best practices.

## Additional Notes
N/A