### PR TITLE
Split conformance pack into 2 parts

### DIFF
--- a/arch/templates/ConformancePack1.yaml
+++ b/arch/templates/ConformancePack1.yaml
@@ -79,26 +79,6 @@ Parameters:
     Type: String
   S3SecureNetworkTransmissionPolicyPath:
     Type: String
-  # GC08
-  S3TargetNetworkArchitecturePath:
-    Type: String
-  S3TargetCloudDeploymentGuideDocumentPath:
-    Type: String
-  S3TargetCloudSegmentationDesignDocumentPath:
-    Type: String
-  # GC09
-  S3NetworkArchitectureDocumentPath:
-    Type: String
-  # GC10
-  S3SignedMOUDocumentPath:
-    Type: String
-  # GC13
-  S3AccountManagementProcedurePath:
-    Type: String
-  S3AccountMgmtApprovalsPath:
-    Type: String
-  S3EmergencyAccountAlertsRuleNamesPath:
-    Type: String
 Resources:
   # GC01
   GC01CheckAttestationLetterConfigRule:
@@ -169,7 +149,6 @@ Resources:
         SourceDetails:
           - EventSource: "aws.config"
             MessageType: "ScheduledNotification"
-
   GC01CheckFederatedUsersMFA:
     Type: "AWS::Config::ConfigRule"
     Properties:
@@ -201,7 +180,6 @@ Resources:
         SourceDetails:
           - EventSource: "aws.config"
             MessageType: "ScheduledNotification"
-
   GC01CheckMonitoringAndLogging:
     Type: "AWS::Config::ConfigRule"
     Properties:
@@ -234,7 +212,6 @@ Resources:
         SourceDetails:
           - EventSource: "aws.config"
             MessageType: "ScheduledNotification"
-
   GC01CheckAlertsFlagMisuseConfigRule:
     Type: "AWS::Config::ConfigRule"
     Properties:
@@ -272,7 +249,6 @@ Resources:
         SourceDetails:
           - EventSource: "aws.config"
             MessageType: "ScheduledNotification"
-
   GC01CheckMFADigitalPolicy:
     Type: "AWS::Config::ConfigRule"
     Properties:
@@ -301,43 +277,6 @@ Resources:
             - - "arn:aws:lambda:ca-central-1:"
               - Ref: AuditAccountID
               - !Sub ":function:${OrganizationName}gc01_check_mfa_digital_policy"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  # GC02
-  GC02CheckAccountManagementPlanConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc02_check_account_mgmt_plan
-      Description: Checks S3 bucket for the account management plan document
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3AccountManagementPlanPath
-            - Ref: S3AccountManagementPlanPath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc02_check_account_mgmt_plan"
         SourceDetails:
           - EventSource: "aws.config"
             MessageType: "ScheduledNotification"
@@ -380,6 +319,43 @@ Resources:
             - - "arn:aws:lambda:ca-central-1:"
               - Ref: AuditAccountID
               - !Sub ":function:${OrganizationName}gc01_check_iam_users_mfa"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  # GC02
+  GC02CheckAccountManagementPlanConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc02_check_account_mgmt_plan
+      Description: Checks S3 bucket for the account management plan document
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3AccountManagementPlanPath
+            - Ref: S3AccountManagementPlanPath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc02_check_account_mgmt_plan"
         SourceDetails:
           - EventSource: "aws.config"
             MessageType: "ScheduledNotification"
@@ -882,461 +858,6 @@ Resources:
         SourceDetails:
           - EventSource: "aws.config"
             MessageType: "ScheduledNotification"
-  # GC08
-  GC08CheckTargetNetworkArchitectureConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc08_check_target_network_architecture
-      Description: Checks S3 bucket for the target network architecture document
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3TargetNetworkArchitecturePath
-            - Ref: S3TargetNetworkArchitecturePath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc08_check_target_network_architecture"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  GC08CheckCloudDeploymentGuideConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc08_check_cloud_deployment_guide
-      Description: Checks S3 bucket for the cloud deployment guide document
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3TargetCloudDeploymentGuideDocumentPath
-            - Ref: S3TargetCloudDeploymentGuideDocumentPath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc08_check_cloud_deployment_guide"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  GC08CheckCloudSegmentationDesignConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc08_check_cloud_segmentation_design
-      Description: Checks S3 bucket for the cloud segmentation guide document
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3TargetCloudSegmentationDesignDocumentPath
-            - Ref: S3TargetCloudSegmentationDesignDocumentPath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc08_check_cloud_segmentation_design"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  # GC09
-  GC09CheckNetworkSecurityArchitectureConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc09_check_netsec_architecture
-      Description: Checks S3 bucket for the network security architecture document
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3NetworkArchitectureDocumentPath
-            - Ref: S3NetworkArchitectureDocumentPath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc09_check_netsec_architecture"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  # GC10
-  GC10CheckSignedMOUConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc10_confirmation_of_mou
-      Description: Confirms if the signed MOU with CCS has been uploaded to the S3 bucket
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3SignedMOUDocumentPath
-            - Ref: S3SignedMOUDocumentPath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc10_confirmation_of_mou"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  # GC11 - Check Security Contact
-  GC11CheckSecurityContactConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc11_check_security_contact
-      Description: Confirms that the account valid alternate security contact configured
-      InputParameters:
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc11_check_security_contact"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  # GC11 - Check Trail Logging
-  GC11CheckTrailLoggingConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc11_check_trail_logging
-      Description: Confirms that the AWS CloudTrail trails are logging
-      InputParameters:
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc11_check_trail_logging"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-  # GC11 - Cloud Trail check with AWS Managed rules CLOUD_TRAIL_ENABLED, CLOUDTRAIL_S3_DATAEVENTS_ENABLED, CLOUDTRAIL_SECURITY_TRAIL_ENABLED
-  GC11CloudTrailEnabledConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc11_cloud_trail_enabled
-      Source:
-        Owner: AWS
-        SourceIdentifier: CLOUD_TRAIL_ENABLED
-  GC11CloudTrailS3DataEventsEnabledConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc11_cloudtrail_s3_dataevents_enabled
-      Source:
-        Owner: AWS
-        SourceIdentifier: CLOUDTRAIL_S3_DATAEVENTS_ENABLED
-  GC11CloudTrailSecurityTrailEnabledConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc11_cloudtrail_security_trail_enabled
-      Source:
-        Owner: AWS
-        SourceIdentifier: CLOUDTRAIL_SECURITY_TRAIL_ENABLED
-  # GC12 - Check Trail Logging
-  GC12CheckPrivateMarketplaceConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc12_check_private_marketplace
-      Description: Confirms that the account has access to an AWS Private Marketplace
-      InputParameters:
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc12_check_marketplace"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-
-  # GC13
-  GC13EmergencyAccountManagementConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc13_emergency_account_management
-      Description: Checks S3 bucket for the account management procedure
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3AccountManagementProcedurePath
-            - Ref: S3AccountManagementProcedurePath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc13_emergency_account_management"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-
-  GC13EmergencyAccountMgmtApprovalsConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc13_emergency_account_mgmt_approvals
-      Description: Checks S3 bucket for the account management procedure approvals
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3AccountMgmtApprovalsPath
-            - Ref: S3AccountMgmtApprovalsPath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc13_emergency_account_mgmt_approvals"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-
-  GC13EmergencyAccountAlertsConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc13_emergency_account_alerts
-      Description: Checks for the existence of alerts that are in place to report any use of emergency accounts
-      InputParameters:
-        s3ObjectPath:
-          Fn::If:
-            - s3EmergencyAccountAlertsRuleNamesPath
-            - Ref: S3EmergencyAccountAlertsRuleNamesPath
-            - Ref: AWS::NoValue
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc13_emergency_account_alerts"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
-
-  GC13EmergencyAccountTestingConfigRule:
-    Type: "AWS::Config::ConfigRule"
-    Properties:
-      ConfigRuleName: gc13_emergency_account_testing
-      Description: Verifies that testing of emergency accounts took place and that periodic testing is included
-      InputParameters:
-        ExecutionRoleName:
-          Fn::If:
-            - GCLambdaExecutionRoleName
-            - Ref: GCLambdaExecutionRoleName
-            - Ref: AWS::NoValue
-        AuditAccountID:
-          Fn::If:
-            - auditAccountID
-            - Ref: AuditAccountID
-            - Ref: AWS::NoValue
-        BgUser1:
-          Fn::If:
-            - bgUser1
-            - Ref: BGA1
-            - Ref: AWS::NoValue
-        BgUser2:
-          Fn::If:
-            - bgUser2
-            - Ref: BGA2
-            - Ref: AWS::NoValue
-      Scope:
-        ComplianceResourceTypes:
-          - AWS::Account
-      MaximumExecutionFrequency: TwentyFour_Hours
-      Source:
-        Owner: CUSTOM_LAMBDA
-        SourceIdentifier:
-          Fn::Join:
-            - ""
-            - - "arn:aws:lambda:ca-central-1:"
-              - Ref: AuditAccountID
-              - !Sub ":function:${OrganizationName}gc13_emergency_account_testing"
-        SourceDetails:
-          - EventSource: "aws.config"
-            MessageType: "ScheduledNotification"
 
 Conditions:
   # Common
@@ -1471,47 +992,3 @@ Conditions:
       - Fn::Equals:
           - ""
           - Ref: S3SecureNetworkTransmissionPolicyPath
-  # GC08
-  s3TargetNetworkArchitecturePath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3TargetNetworkArchitecturePath
-  s3TargetCloudDeploymentGuideDocumentPath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3TargetCloudDeploymentGuideDocumentPath
-  s3TargetCloudSegmentationDesignDocumentPath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3TargetCloudSegmentationDesignDocumentPath
-  # GC09
-  s3NetworkArchitectureDocumentPath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3NetworkArchitectureDocumentPath
-  # GC09
-  s3SignedMOUDocumentPath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3SignedMOUDocumentPath
-  # GC13
-  s3AccountManagementProcedurePath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3AccountManagementProcedurePath
-  s3AccountMgmtApprovalsPath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3AccountMgmtApprovalsPath
-  s3EmergencyAccountAlertsRuleNamesPath:
-    Fn::Not:
-      - Fn::Equals:
-          - ""
-          - Ref: S3EmergencyAccountAlertsRuleNamesPath

--- a/arch/templates/ConformancePack2.yaml
+++ b/arch/templates/ConformancePack2.yaml
@@ -1,0 +1,563 @@
+##################################################################################
+#   Conformance Pack: Government of Canada Guardrails
+#   This conformance pack helps verify compliance with CIS AWS Foundations Benchmark Level 1 requirements.
+#   See Parameters section for names and descriptions of required parameters.
+##################################################################################
+Parameters:
+  # Common
+  GCLambdaExecutionRoleName:
+    Type: String
+  GCLambdaExecutionRoleName2:
+    Type: String
+  AuditAccountID:
+    Type: String
+  BGA1:
+    Type: String
+  BGA2:
+    Type: String
+  OrganizationName:
+    Type: String
+  DeployVersion:
+    Type: String
+  # GC08
+  S3TargetNetworkArchitecturePath:
+    Type: String
+  S3TargetCloudDeploymentGuideDocumentPath:
+    Type: String
+  S3TargetCloudSegmentationDesignDocumentPath:
+    Type: String
+  # GC09
+  S3NetworkArchitectureDocumentPath:
+    Type: String
+  # GC10
+  S3SignedMOUDocumentPath:
+    Type: String
+  # GC13
+  S3AccountManagementProcedurePath:
+    Type: String
+  S3AccountMgmtApprovalsPath:
+    Type: String
+  S3EmergencyAccountAlertsRuleNamesPath:
+    Type: String
+Resources:
+  # GC08
+  GC08CheckTargetNetworkArchitectureConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc08_check_target_network_architecture
+      Description: Checks S3 bucket for the target network architecture document
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3TargetNetworkArchitecturePath
+            - Ref: S3TargetNetworkArchitecturePath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc08_check_target_network_architecture"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  GC08CheckCloudDeploymentGuideConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc08_check_cloud_deployment_guide
+      Description: Checks S3 bucket for the cloud deployment guide document
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3TargetCloudDeploymentGuideDocumentPath
+            - Ref: S3TargetCloudDeploymentGuideDocumentPath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc08_check_cloud_deployment_guide"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  GC08CheckCloudSegmentationDesignConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc08_check_cloud_segmentation_design
+      Description: Checks S3 bucket for the cloud segmentation guide document
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3TargetCloudSegmentationDesignDocumentPath
+            - Ref: S3TargetCloudSegmentationDesignDocumentPath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc08_check_cloud_segmentation_design"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  # GC09
+  GC09CheckNetworkSecurityArchitectureConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc09_check_netsec_architecture
+      Description: Checks S3 bucket for the network security architecture document
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3NetworkArchitectureDocumentPath
+            - Ref: S3NetworkArchitectureDocumentPath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc09_check_netsec_architecture"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  # GC10
+  GC10CheckSignedMOUConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc10_confirmation_of_mou
+      Description: Confirms if the signed MOU with CCS has been uploaded to the S3 bucket
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3SignedMOUDocumentPath
+            - Ref: S3SignedMOUDocumentPath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc10_confirmation_of_mou"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  # GC11
+  GC11CheckSecurityContactConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc11_check_security_contact
+      Description: Confirms that the account valid alternate security contact configured
+      InputParameters:
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc11_check_security_contact"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  GC11CheckTrailLoggingConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc11_check_trail_logging
+      Description: Confirms that the AWS CloudTrail trails are logging
+      InputParameters:
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc11_check_trail_logging"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  GC11CloudTrailEnabledConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc11_cloud_trail_enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CLOUD_TRAIL_ENABLED
+  GC11CloudTrailS3DataEventsEnabledConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc11_cloudtrail_s3_dataevents_enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CLOUDTRAIL_S3_DATAEVENTS_ENABLED
+  GC11CloudTrailSecurityTrailEnabledConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc11_cloudtrail_security_trail_enabled
+      Source:
+        Owner: AWS
+        SourceIdentifier: CLOUDTRAIL_SECURITY_TRAIL_ENABLED
+  # GC12
+  GC12CheckPrivateMarketplaceConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc12_check_private_marketplace
+      Description: Confirms that the account has access to an AWS Private Marketplace
+      InputParameters:
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc12_check_marketplace"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  # GC13
+  GC13EmergencyAccountManagementConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc13_emergency_account_management
+      Description: Checks S3 bucket for the account management procedure
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3AccountManagementProcedurePath
+            - Ref: S3AccountManagementProcedurePath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc13_emergency_account_management"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  GC13EmergencyAccountMgmtApprovalsConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc13_emergency_account_mgmt_approvals
+      Description: Checks S3 bucket for the account management procedure approvals
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3AccountMgmtApprovalsPath
+            - Ref: S3AccountMgmtApprovalsPath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc13_emergency_account_mgmt_approvals"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  GC13EmergencyAccountAlertsConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc13_emergency_account_alerts
+      Description: Checks for the existence of alerts that are in place to report any use of emergency accounts
+      InputParameters:
+        s3ObjectPath:
+          Fn::If:
+            - s3EmergencyAccountAlertsRuleNamesPath
+            - Ref: S3EmergencyAccountAlertsRuleNamesPath
+            - Ref: AWS::NoValue
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc13_emergency_account_alerts"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+  GC13EmergencyAccountTestingConfigRule:
+    Type: "AWS::Config::ConfigRule"
+    Properties:
+      ConfigRuleName: gc13_emergency_account_testing
+      Description: Verifies that testing of emergency accounts took place and that periodic testing is included
+      InputParameters:
+        ExecutionRoleName:
+          Fn::If:
+            - GCLambdaExecutionRoleName
+            - Ref: GCLambdaExecutionRoleName
+            - Ref: AWS::NoValue
+        AuditAccountID:
+          Fn::If:
+            - auditAccountID
+            - Ref: AuditAccountID
+            - Ref: AWS::NoValue
+        BgUser1:
+          Fn::If:
+            - bgUser1
+            - Ref: BGA1
+            - Ref: AWS::NoValue
+        BgUser2:
+          Fn::If:
+            - bgUser2
+            - Ref: BGA2
+            - Ref: AWS::NoValue
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::Account
+      MaximumExecutionFrequency: TwentyFour_Hours
+      Source:
+        Owner: CUSTOM_LAMBDA
+        SourceIdentifier:
+          Fn::Join:
+            - ""
+            - - "arn:aws:lambda:ca-central-1:"
+              - Ref: AuditAccountID
+              - !Sub ":function:${OrganizationName}gc13_emergency_account_testing"
+        SourceDetails:
+          - EventSource: "aws.config"
+            MessageType: "ScheduledNotification"
+
+Conditions:
+  # Common
+  GCLambdaExecutionRoleName:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: GCLambdaExecutionRoleName
+  GCLambdaExecutionRoleName2:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: GCLambdaExecutionRoleName2
+  auditAccountID:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: AuditAccountID
+  bgUser1:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: BGA1
+  bgUser2:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: BGA2
+  # GC08
+  s3TargetNetworkArchitecturePath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3TargetNetworkArchitecturePath
+  s3TargetCloudDeploymentGuideDocumentPath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3TargetCloudDeploymentGuideDocumentPath
+  s3TargetCloudSegmentationDesignDocumentPath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3TargetCloudSegmentationDesignDocumentPath
+  # GC09
+  s3NetworkArchitectureDocumentPath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3NetworkArchitectureDocumentPath
+  # GC09
+  s3SignedMOUDocumentPath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3SignedMOUDocumentPath
+  # GC13
+  s3AccountManagementProcedurePath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3AccountManagementProcedurePath
+  s3AccountMgmtApprovalsPath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3AccountMgmtApprovalsPath
+  s3EmergencyAccountAlertsRuleNamesPath:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: S3EmergencyAccountAlertsRuleNamesPath

--- a/arch/templates/main.yaml
+++ b/arch/templates/main.yaml
@@ -1378,7 +1378,7 @@ Resources:
   #######################################################
   # Part 4 - Conformance Pack
   #######################################################
-  ConformancePack:
+  ConformancePack1:
     DependsOn:
       - AuditAccountPreRequisitesPart1
       - AuditAccountPreRequisitesPart2
@@ -1425,6 +1425,10 @@ Resources:
           ParameterValue: !Sub
             - "s3://${ClientEvidenceBucket}/gc-02/account_management_plan.pdf"
             - ClientEvidenceBucket: !If [ GenerateEvidenceBucketName, !GetAtt GenerateEvidenceBucketName.EvidenceBucketName, !Ref EvidenceBucketName ]
+        - ParameterName: S3VpnIpRangesPath
+          ParameterValue: !Sub
+            - "s3://${ClientEvidenceBucket}/gc-03/vpn_ip_ranges.txt"
+            - ClientEvidenceBucket: !If [ GenerateEvidenceBucketName, !GetAtt GenerateEvidenceBucketName.EvidenceBucketName, !Ref EvidenceBucketName ]
         - ParameterName: S3ProtectedBServiceLocationDocumentPath
           ParameterValue: !Sub
             - "s3://${ClientEvidenceBucket}/gc-05/service_location_protectedb.pdf"
@@ -1445,6 +1449,38 @@ Resources:
           ParameterValue: !Sub
             - "s3://${ClientEvidenceBucket}/gc-07/secure_network_transmission.pdf"
             - ClientEvidenceBucket: !If [ GenerateEvidenceBucketName, !GetAtt GenerateEvidenceBucketName.EvidenceBucketName, !Ref EvidenceBucketName ]
+      OrganizationConformancePackName: !Sub "${OrganizationName}-GC-CP-Guardrails-Part-1"
+      TemplateS3Uri: !Sub s3://${PipelineBucket}/${DeployVersion}/ConformancePack1.yaml
+  
+  ConformancePack2:
+    DependsOn:
+      - AuditAccountPreRequisitesPart1
+      - AuditAccountPreRequisitesPart2
+      - AuditAccountPreRequisitesPart3
+      - AuditAccountPreRequisitesPart4
+      - AuditAccountPreRequisitesPart5
+      - AuditAccountPreRequisitesPart6
+      - AuditAccountPreRequisitesPart7
+      - AuditAccountPreRequisitesPart8
+      - AuditAccountPreRequisitesPartN
+      #- AllAccountPreRequisites
+    Type: AWS::Config::OrganizationConformancePack
+    Properties:
+      ConformancePackInputParameters:
+        - ParameterName: GCLambdaExecutionRoleName
+          ParameterValue: !Sub "${AccelRolePrefix}GCLambdaExecutionRole"
+        - ParameterName: GCLambdaExecutionRoleName2
+          ParameterValue: !Sub ${AccelRolePrefix}GCLambdaExecutionRole2
+        - ParameterName: AuditAccountID
+          ParameterValue: !Ref AuditAccountID
+        - ParameterName: DeployVersion
+          ParameterValue: !Ref DeployVersion
+        - ParameterName: BGA1
+          ParameterValue: !Ref BGA1
+        - ParameterName: BGA2
+          ParameterValue: !Ref BGA2
+        - ParameterName: OrganizationName
+          ParameterValue: !Ref OrganizationName
         - ParameterName: S3TargetNetworkArchitecturePath
           ParameterValue: !Sub
             - "s3://${ClientEvidenceBucket}/gc-08/target_network_architecture.pdf"
@@ -1477,12 +1513,8 @@ Resources:
           ParameterValue: !Sub
             - "s3://${ClientEvidenceBucket}/gc-13/rule_names.txt"
             - ClientEvidenceBucket: !If [ GenerateEvidenceBucketName, !GetAtt GenerateEvidenceBucketName.EvidenceBucketName, !Ref EvidenceBucketName ]
-        - ParameterName: S3VpnIpRangesPath
-          ParameterValue: !Sub
-            - "s3://${ClientEvidenceBucket}/gc-03/vpn_ip_ranges.txt"
-            - ClientEvidenceBucket: !If [ GenerateEvidenceBucketName, !GetAtt GenerateEvidenceBucketName.EvidenceBucketName, !Ref EvidenceBucketName ]
-      OrganizationConformancePackName: !Sub "${OrganizationName}-GC-CP-Guardrails"
-      TemplateS3Uri: !Sub s3://${PipelineBucket}/${DeployVersion}/ConformancePack.yaml
+      OrganizationConformancePackName: !Sub "${OrganizationName}-GC-CP-Guardrails-Part-2"
+      TemplateS3Uri: !Sub s3://${PipelineBucket}/${DeployVersion}/ConformancePack2.yaml
 
   #######################################################
   # Part 5 - Audit Manager Components
@@ -1492,6 +1524,7 @@ Resources:
     DependsOn:
       - AWSAuditManagerOrganizationsSetup
       - ConformancePack
+      - ConformancePack2
       - AuditAccountPreRequisitesPart1
       - AuditAccountPreRequisitesPart2
       - AuditAccountPreRequisitesPart3


### PR DESCRIPTION
# AWS CAC Solution PR Template

## Pull Request Type
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation Update
- [ ] Other (Please specify)

## Description
When adding more guardrails to the conformance pack (GR10 & GR11), the deployment kept failing. There seemed to be a cutoff of the conformance pack file where the last parameters were not being included. This is to split the conformance pack in half so that the size of each half does not cause limits to be reached and the deployment to fail. 

## Related Issue(s)
List any related issues here. Include `Fixes #issue_number` or `Closes #issue_number` if applicable.

## How Has This Been Tested?
Describe how you have tested these changes. Include details of the testing environment and the tests you ran to verify the functionality.

### CloudFormation Linter Results
Include the output of the CloudFormation linter (if used).

### Deployment Test Results
Provide details of any deployment tests you have conducted.

## Screenshots (if appropriate)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated any related documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes generate no new warnings.
- [ ] I have added comments to my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes require a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the final deliverable aligns with the CloudFormation best practices.

## Additional Notes
Include any additional information that you think is important for reviewers.
