### PR TITLE
Fix paging active accounts for audit manager setup lambda

### DIFF
--- a/src/lambda/aws_auditmanager_resources_config_setup/app.py
+++ b/src/lambda/aws_auditmanager_resources_config_setup/app.py
@@ -367,7 +367,7 @@ def get_active_accounts():
             next_token = response.get("NextToken")
             while next_token:
                 response = client.list_accounts(NextToken=next_token)
-                accounts.append(response.get("Accounts"))
+                accounts.extend(response.get("Accounts"))
                 next_token = response.get("NextToken")
             for account in accounts:
                 if account.get("Status", "") == "ACTIVE":


### PR DESCRIPTION
# Fix paging active accounts for audit manager setup lambda

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation Update
- [ ] Other (Please specify)

## Description
Changing how the accounts list get populated when it start paging. append was adding the paged list into the list, and not the list items.
Error output:
```
[ERROR] AttributeError: 'list' object has no attribute 'get'
Traceback (most recent call last):
  File "/var/task/app.py", line 702, in lambda_handler
    result = create_auditmanager_resources(
  File "/var/task/app.py", line 522, in create_auditmanager_resources
    result = create_assessment(
  File "/var/task/app.py", line 417, in create_assessment
    aws_accounts = get_active_accounts()
  File "/var/task/app.py", line 373, in get_active_accounts
    if account.get("Status", "") == "ACTIVE":
```

## Related Issue(s)
https://github.com/NRCan/aws-guardrails-cac-solution/issues/1

## How Has This Been Tested?
Deployed into NRCan LZA org.

### Deployment Test Results
Could not be deployed, would failed during execution. With this change, deployment of 2.0.4 is now successful.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated any related documentation.
- [ ] I have read the **CONTRIBUTING** document. 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [ ] I have added comments to my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes require a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the final deliverable aligns with the CloudFormation best practices.