### PR TITLE
gc01_check_alerts_flag_misuse bug fix

### DIFF
--- a/src/lambda/gc01_check_alerts_flag_misuse/app.py
+++ b/src/lambda/gc01_check_alerts_flag_misuse/app.py
@@ -165,7 +165,7 @@ def check_alerts_flag_misuse(event, rule_parameters, aws_account_id, evaluations
             evaluations = []
             is_compliant = False
             rule_naming_convention = read_s3_object(aws_s3_client, rule_naming_convention_file_path)
-            reg = re.compile(rule_naming_convention)
+            reg = re.compile(rule_naming_convention.strip())
             logger.info("Filtering rules by rule_naming_convention: %s", rule_naming_convention)
             filtered_rules = [r for r in rules if reg.search(r.get("Name", ""))]
 


### PR DESCRIPTION
# AWS CAC Solution PR Template

## Pull Request Type
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation Update
- [ ] Other (Please specify)

## Description
Modified line 168 of gc01_check_alerts_flag_misuse/app.py to strip leading and trailing whitespaces from the pattern configured in `rule_naming_convention.txt` prior to using it for a regex search of matching EventBridge rule names. This fixes a bug in which trailing newlines, sometimes present when reading S3 object contents, prevent correct identification of eligible EventBridge rules, causing an automatic NONCOMPLIANT for this lambda.

## Related Issue(s)
 Closes #170 

## How Has This Been Tested?
Bug has been reproduced by:

- Creating a rule_naming_convention.txt file within a Linux environment (AWS CloudShell) with the contents being the single line of text "guardrails" without a terminating newline.
- Uploading to S3 via AWS CLI
- Reading the contents of the created S3 object with the read_s3_object utility function defined in this repo
observing that the returned string literal is "guardrails\n"

Considering that EventBridge rule names must be a "Maximum of 64 characters consisting of numbers, lower/upper case letters, .,-,_.", adding the `.strip()` to remove leading and trailing whitespaces should not compromise any valid patterns. I will create a PR with this solution.

### CloudFormation Linter Results
Include the output of the CloudFormation linter (if used).

### Deployment Test Results
Provide details of any deployment tests you have conducted.

## Screenshots (if appropriate)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated any related documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes generate no new warnings.
- [ ] I have added comments to my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes require a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the final deliverable aligns with the CloudFormation best practices.

## Additional Notes
Include any additional information that you think is important for reviewers.
